### PR TITLE
更严格遵循m3u规范，删除"#EXTINF:-1"后面的逗号","

### DIFF
--- a/migu.php
+++ b/migu.php
@@ -139,7 +139,7 @@ class MiguParser
         $str = '#EXTM3U x-tvg-url="https://live.fanmingming.com/e.xml"' . PHP_EOL;
         foreach ($this->channelList as $group => $groupList) {
             foreach ($groupList as $channelId => $channelName) {
-                $str .= sprintf('#EXTINF:-1,tvg-id="%s" tvg-name="%s" tvg-logo="https://live.fanmingming.com/tv/%s.png" group-title="%s",%s%s%s%s%s', $channelName, $channelName, $channelName, $group, $channelName, PHP_EOL, $this->selfJumpUrl, $channelId, PHP_EOL);
+                $str .= sprintf('#EXTINF:-1 tvg-id="%s" tvg-name="%s" tvg-logo="https://live.fanmingming.com/tv/%s.png" group-title="%s",%s%s%s%s%s', $channelName, $channelName, $channelName, $group, $channelName, PHP_EOL, $this->selfJumpUrl, $channelId, PHP_EOL);
             }
         }
         return $str;

--- a/tptv.php
+++ b/tptv.php
@@ -178,7 +178,7 @@ class M3uParser
                 continue;
             }
             foreach ($this->m3uDataArrFormat[$groupOld] as $item) {
-                $str .= sprintf('#EXTINF:%s,tvg-id="%s" tvg-name="%s" tvg-logo="%s" group-title="%s",%s%s%s%s', $item["inf"], $item["id"], $item["id"], $item["logo"], $groupNew, $item["desc"], PHP_EOL, $item["url"], PHP_EOL);
+                $str .= sprintf('#EXTINF:%s tvg-id="%s" tvg-name="%s" tvg-logo="%s" group-title="%s",%s%s%s%s', $item["inf"], $item["id"], $item["id"], $item["logo"], $groupNew, $item["desc"], PHP_EOL, $item["url"], PHP_EOL);
             }
         }
         return $str;

--- a/tv.php
+++ b/tv.php
@@ -241,12 +241,12 @@ class M3uParser
                     }
                 }
                 foreach ($tmpM3uDataArrMerge as $item) {
-                    $str .= sprintf('#EXTINF:%s,tvg-id="%s" tvg-name="%s" tvg-logo="%s" group-title="%s",%s%s%s%s', $item["inf"], $item["id"], $item["id"], $item["logo"], $groupNew, $item["desc"], PHP_EOL, implode(PHP_EOL, $item["url"]), PHP_EOL);
+                    $str .= sprintf('#EXTINF:%s tvg-id="%s" tvg-name="%s" tvg-logo="%s" group-title="%s",%s%s%s%s', $item["inf"], $item["id"], $item["id"], $item["logo"], $groupNew, $item["desc"], PHP_EOL, implode(PHP_EOL, $item["url"]), PHP_EOL);
                 }
             } else {
                 if (isset($this->m3uDataArrFormat[$groupOld])) {
                     foreach ($this->m3uDataArrFormat[$groupOld] as $item) {
-                        $str .= sprintf('#EXTINF:%s,tvg-id="%s" tvg-name="%s" tvg-logo="%s" group-title="%s",%s%s%s%s', $item["inf"], $item["id"], $item["id"], $item["logo"], $groupNew, $item["desc"], PHP_EOL, $item["url"], PHP_EOL);
+                        $str .= sprintf('#EXTINF:%s tvg-id="%s" tvg-name="%s" tvg-logo="%s" group-title="%s",%s%s%s%s', $item["inf"], $item["id"], $item["id"], $item["logo"], $groupNew, $item["desc"], PHP_EOL, $item["url"], PHP_EOL);
                     }
                 }
             }


### PR DESCRIPTION
因为"#EXTINF:-1"后面的这一个逗号，我的mac播放器IINA，以及聚合服务器tvheadend都无法识别频道名称。

肥羊原始m3u也有这个逗号，我想跟肥羊反馈，但是肥羊没提供除tg外的其他反馈渠道（tg群太水了群主没看到）。